### PR TITLE
build: autoinstall requirements when running commands

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y hugo pandoc
-        make _virtualenv
     - name: Validate the updated file
       run: make build
     - name: Archive artifact

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y hugo pandoc
     - name: Validate the updated file
       run: make build
     - name: Archive artifact

--- a/.github/workflows/subscribe.yml
+++ b/.github/workflows/subscribe.yml
@@ -26,8 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install dependencies
-      run: sudo apt-get install -y libxml2-utils
     - name: Add entry to OPML file
       run: "make opml-subscribe OPML_URL='${{ inputs.url }}' OPML_TITLE='${{ inputs.title }}' OPML_WEBSITE='${{ inputs.website }}' OPML_FILE='${{ inputs.file }}'"
     - name: Validate the updated file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y hugo
     - name: Confirm the build script runs
       run: make lint-hugo
   test-python:
@@ -35,8 +32,5 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y pandoc
     - name: Run the python tests
       run: make test-python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,6 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        make _virtualenv
-        ./.venv/bin/pip install pylint
     - name: Analysing the code with pylint
       run: make lint-python
   lint-hugo:
@@ -43,8 +38,5 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y pandoc
-        python -m pip install --upgrade pip
-        make _virtualenv
-        ./.venv/bin/pip install coverage
     - name: Run the python tests
       run: make test-python

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,7 +21,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y hugo pandoc
-        make _virtualenv
     - name: Fetch content updates
       run: |
         git config --global user.name "${GITHUB_REPOSITORY%/*}"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,9 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y hugo pandoc
     - name: Fetch content updates
       run: |
         git config --global user.name "${GITHUB_REPOSITORY%/*}"

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,4 @@ include lib/make/opml.mk
 include lib/make/git.mk
 include lib/make/python.mk
 include lib/make/test.mk
+include lib/make/requirements.mk

--- a/lib/make/hugo.mk
+++ b/lib/make/hugo.mk
@@ -5,25 +5,25 @@ HUGO_THEME=$(shell $(PYTHON) ./bin/get-key-from-yaml.py $(HUGO_SITE_NAME)/config
 HUGO_CONFIG_FILE=$(HUGO_SITE_NAME)/config.yaml
 
 .PHONY: serve
-serve:  ## Serve up a preview instance of the site
+serve: requirements-system  ## Serve up a preview instance of the site
 	cd "$(HUGO_SITE_NAME)" && \
 		"$(HUGO)" server $(HUGO_FLAGS)
 
 .PHONY: build
-build:  ## Build the Hugo site
+build: requirements-system  ## Build the Hugo site
 	cd "$(HUGO_SITE_NAME)" \
 		&& $(HUGO) mod get -u "$(HUGO_THEME)" \
 		&& "$(HUGO)" $(HUGO_FLAGS) \
 	;
 
-init:  ## Initialize an empty repository
+init: requirements-system  ## Initialize an empty repository
 	"$(HUGO)" new site "$(HUGO_SITE_NAME)"
 	echo "podcasts: {}" >> "$(HUGO_CONFIG_FILE)"
 	mkdir -p dist/content
 	mkdir -p dist/static
 
 .PHONY: update-theme
-update-theme:  ## Check for and download new versions of the Hugo Theme
+update-theme: requirements-system  ## Check for and download new versions of the Hugo Theme
 	$(call assert-not-has-changes-saved,)
 	$(call assert-not-has-changes-to-file,src/go.mod src/go.sum)
 	cd "$(HUGO_SITE_NAME)" && \

--- a/lib/make/opml.mk
+++ b/lib/make/opml.mk
@@ -22,11 +22,5 @@ else
 		"$(OPML_FILE_BACKUP)" \
 	>"$(OPML_FILE)"
 	rm "$(OPML_FILE_BACKUP)"
-ifneq (,$(GIT_COMMIT))
-	$(GIT) add "$(OPML_FILE)"
-	$(GIT) commit -m "feat: subscribe to new feed; $(OPML_TITLE)"
-ifneq (,$(GIT_PUSH))
-	$(GIT) push "$(GIT_REMOTE_CONTENT)" "$(GIT_BRANCH_CURRENT)"
-endif
-endif
+	$(call git-commit-path,$(OPML_FILE),feat: subscribe to new feed; $(OPML_TITLE))
 endif

--- a/lib/make/opml.mk
+++ b/lib/make/opml.mk
@@ -7,7 +7,7 @@ OPML_TITLE=$(OPML_URL)
 endif
 
 .PHONY: opml-subscribe
-opml-subscribe:  ## Subscribe to a new feed
+opml-subscribe: requirements-system  ## Subscribe to a new feed
 ifndef OPML_URL
 	@echo "Usage: make opml-subscribe OPML_URL='https://.../index.xml' OPML_TITLE='...' OPML_WEBSITE='https://.../index.html'"
 	exit 1

--- a/lib/make/python.mk
+++ b/lib/make/python.mk
@@ -15,13 +15,13 @@ $(PYTHON) bin/parse-feed.py '$(1)' \
 ;
 endef
 
-.PHONY: _virtualenv
-_virtualenv:  ## Create a new virtualenv and install packages
+.PHONY: requirements-python
+requirements-python: requirements-system  ## Create a new virtualenv and install packages
 	test -d ./.venv || python3 -m venv ./.venv
 	./.venv/bin/pip install -r "$(PYTHON_REQUIREMENTS)"
 
 .PHONY: update-content
-update-content: _virtualenv  ## Update content/metadata for feeds
+update-content: requirements-python  ## Update content/metadata for feeds
 	$(call assert-not-has-changes-saved,)
 	$(call assert-not-has-changes-to-file,dist/content)
 	$(call git-checkout-branch,$(GIT_BRANCH_CONTENT))
@@ -30,7 +30,7 @@ update-content: _virtualenv  ## Update content/metadata for feeds
 	$(call git-commit-path,dist/content,feat: update content)
 
 .PHONY: update-static
-update-static:  ## Fetch static assets (images/audio/video)
+update-static: requirements-python  ## Fetch static assets (images/audio/video)
 	$(call assert-not-has-changes-saved,)
 	$(call assert-not-has-changes-to-file,dist/static)
 	$(call git-checkout-branch,$(GIT_BRANCH_STATIC))
@@ -42,5 +42,5 @@ endif
 	$(call git-commit-path,dist/static,feat: update static)
 
 .PHONY: update-feeds
-update-feeds:
+update-feeds: requirements-python
 	$(PYTHON) bin/parse-opml.py "$(OPML_FILE)" dist --content-directory content/content

--- a/lib/make/requirements.mk
+++ b/lib/make/requirements.mk
@@ -1,0 +1,46 @@
+REQUIREMENTS_SYSTEM=hugo pandoc xmllint
+ifneq (,$(shell command -v apt-get))
+APT_REQUIREMENTS_INPUT=lib/requirements.apt.txt
+APT_REQUIREMENTS_OUTPUT_DIRECTORY=tmp
+APT_REQUIREMENTS_OUTPUT=$(APT_REQUIREMENTS_OUTPUT_DIRECTORY)/$(notdir $(APT_REQUIREMENTS_INPUT))
+APT_INSTALL=sudo apt-get install -y
+
+.PHONY: requirements-system
+requirements-system: $(APT_REQUIREMENTS_OUTPUT)  ## Install system requirements
+$(APT_REQUIREMENTS_OUTPUT): $(APT_REQUIREMENTS_INPUT)
+	while read line; do \
+		line=$$(echo "$${line}" | sed 's/^ +//; s/ *#.*$$//;'); \
+		if [ -n "$${line}" ]; then \
+			package=$$(echo "$${line}" | awk '{print $$1}') ; \
+			command=$$(echo "$${line}" | awk '{print $$2}') ; \
+			if [ -n "$${command}" ]; then \
+				if command -v "$${command}" >/dev/null; then \
+					continue; \
+				fi \
+			fi ; \
+			if [ -n "$${package}" ]; then \
+				$(APT_INSTALL) "$${package}"; \
+			fi ; \
+		fi ; \
+	done <'$(APT_REQUIREMENTS_INPUT)'
+	test -d '$(APT_REQUIREMENTS_OUTPUT_DIRECTORY)' || mkdir '$(APT_REQUIREMENTS_OUTPUT_DIRECTORY)'
+	cp '$(<)' '$(@)'
+else
+.PHONY: requirements-system
+requirements-system:
+ifneq (,$(REQUIREMENTS_SYSTEM))
+	@echo "WARN:  We were unable to detect your package manager,"
+	@echo "WARN:  so you will need to ensure the following"
+	@echo "WARN:  executables are available:"
+	@result=0; \
+	for bin in $(REQUIREMENTS_SYSTEM); do \
+		if ! command -v "$${bin}" >/dev/null; then \
+			echo "ERROR:         $${bin} (NOT installed)"; \
+			result=1; \
+		else \
+			echo "WARN:          $${bin} (installed)"; \
+		fi ; \
+	done ; \
+	exit $${result}
+endif
+endif

--- a/lib/make/test.mk
+++ b/lib/make/test.mk
@@ -13,7 +13,7 @@ lint-python-todo: _lint-python-requirements  ## Check for TODO items in Python f
 	$(PYLINT) $(PYTHON_LIB_PATH) --disable all --enable fixme
 
 .PHONY: _lint-python-requirements
-_lint-python-requirements: _virtualenv  ## Install requirements for Python linting
+_lint-python-requirements: requirements-python  ## Install requirements for Python linting
 	$(PIP_INSTALL) pylint
 
 .PHONY:
@@ -22,7 +22,7 @@ test-python: _test-python-requirements  ## Check that the python test suite pass
 	$(COVERAGE) report
 
 .PHONY: _test-python-requirements
-_test-python-requirements: _virtualenv  ## Install requirements for Python testing
+_test-python-requirements: requirements-python  ## Install requirements for Python testing
 	$(PIP_INSTALL) coverage
 
 .PHONY: lint-xml

--- a/lib/make/test.mk
+++ b/lib/make/test.mk
@@ -26,7 +26,7 @@ _test-python-requirements: requirements-python  ## Install requirements for Pyth
 	$(PIP_INSTALL) coverage
 
 .PHONY: lint-xml
-lint-xml:  ## Check that the OPML file is valid
+lint-xml: requirements-system  ## Check that the OPML file is valid
 	# TODO: install requirements
 	$(XMLLINT) $(XMLLINT_FLAGS) "$(OPML_FILE)"
 

--- a/lib/requirements.apt.txt
+++ b/lib/requirements.apt.txt
@@ -1,0 +1,11 @@
+# Package listings take the following form:
+#     package [command]
+# where command is an optional executable.
+# If specified, package is only installed
+#     if command doesn't exist.
+# Commented lines are ignored.
+hugo hugo
+pandoc pandoc
+libxml2-utils xmllint
+# python3
+# git


### PR DESCRIPTION
This reduces the cognitive overhead of remembering to install these,
initially and/or upon changes.

The `Makefile` is supposed to make things easier on us;
let's let it.